### PR TITLE
Fix a typo.

### DIFF
--- a/src/components/library/flex/test/flex.test.js
+++ b/src/components/library/flex/test/flex.test.js
@@ -16,7 +16,7 @@ describe("Flex", () => {
             expect(container.querySelector("div")).toBeTruthy()
         })
 
-        it("passes children trough", () => {
+        it("passes children through", () => {
             expect(screen.getByText(childText)).toBeInTheDocument()
         })
     })


### PR DESCRIPTION
From codespell:

```
./src/components/library/flex/test/flex.test.js:19: trough ==> through
```