### PR TITLE
remove publish from normal ci and only publish on tag

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -138,56 +138,5 @@
         }
       ]
     },
-    publish: {
-      env: { REPORT_DIR: "reports" },
-      name: "Publish library",
-      runs-on: "ubuntu-latest",
-      steps: [
-        {
-          uses: "actions/checkout@v2"
-        },
-        {
-          name: "Set up node ${{ matrix.python-version }}",
-          uses: "actions/setup-node@v2",
-          with: {
-            "node-version": "14.x",
-            registry-url: 'https://npm.pkg.github.com'
-          }
-        },
-        {
-          name: "Get Yarn cache directory",
-          id: "yarn-cache-dir-path",
-          run: "echo \"::set-output name=dir::$(yarn cache dir)\""
-        },
-        {
-          name: "Use Yarn cache",
-          uses: "actions/cache@v2",
-          id: "yarn-cache",
-          with:
-            {
-              path: "${{ steps.yarn-cache-dir-path.outputs.dir }}",
-              key: "${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}"
-            }
-
-        },
-        {
-          name: "Install dependencies",
-          run: "yarn install --prefer-offline"
-        },
-        {
-          name: "Run build",
-          run: "yarn run build"
-        },
-        {
-          name: "Run publish",
-          if: "github.ref == 'refs/heads/master'",
-          run: "npm publish",
-          env: {
-            NODE_AUTH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          }
-        },
-      ]
-    }
   },
-
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+{
+  name: "Build, test and publish ui-components",
+
+  on: {
+    push: {
+      tags:
+        - '*'
+    },
+  },
+
+  jobs: {
+    publish: {
+      env: { REPORT_DIR: "reports" },
+      name: "Publish library",
+      runs-on: "ubuntu-latest",
+      steps: [
+        {
+          uses: "actions/checkout@v2"
+        },
+        {
+          name: "Set up node ${{ matrix.python-version }}",
+          uses: "actions/setup-node@v2",
+          with: {
+            "node-version": "14.x",
+            registry-url: 'https://npm.pkg.github.com'
+          }
+        },
+        {
+          name: "Get Yarn cache directory",
+          id: "yarn-cache-dir-path",
+          run: "echo \"::set-output name=dir::$(yarn cache dir)\""
+        },
+        {
+          name: "Use Yarn cache",
+          uses: "actions/cache@v2",
+          id: "yarn-cache",
+          with:
+            {
+              path: "${{ steps.yarn-cache-dir-path.outputs.dir }}",
+              key: "${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}"
+            }
+
+        },
+        {
+          name: "Install dependencies",
+          run: "yarn install --prefer-offline"
+        },
+        {
+          name: "Run build",
+          run: "yarn run build"
+        },
+        {
+          name: "Run publish",
+          if: "github.ref == 'refs/heads/master'",
+          run: "npm publish",
+          env: {
+            NODE_AUTH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          }
+        },
+      ]
+    }
+  },
+
+}


### PR DESCRIPTION
**What**:

Move from push based releases to tag based releases. A package will now only be created when a new tag is created.

**Why**:

To stop trying to republish the same version again and again.

**How**:

Works in the forked repository. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/ui-components/blob/master/CHANGELOG.md) NA
